### PR TITLE
Decode HTML entities for text format

### DIFF
--- a/index.php
+++ b/index.php
@@ -74,6 +74,7 @@ $license = str_replace('{{info}}', $info, $license);
 if ($format == 'txt') {
   $license = array_shift(explode('</article>', array_pop(explode('<article>', $license))));
   $license = preg_replace('/<[^>]*>/', '', trim($license));
+  $license = html_entity_decode($license);
   header('content-type: text/plain');
 }
 


### PR DESCRIPTION
The default copyright holder contains HTML entities that were displayed as-is in text format.
