### PR TITLE
Escaping HTML characters in user copyright property

### DIFF
--- a/index.php
+++ b/index.php
@@ -13,7 +13,7 @@ $user_file = 'users/'.$user_file.'.json';
 
 if (file_exists($user_file)) {
   $user = json_decode(file_get_contents($user_file));
-  $holder = $user->copyright;
+  $holder = htmlentities($user->copyright);
   if (property_exists($user, 'url')) {
     $holder = '<a href="'.$user->url.'">' . $holder . '</a>';
   }


### PR DESCRIPTION
Fixes issues where people (like me :p) stick angle brackets for URL/email/etc. in copyright property.

I guess it prevents XSS and other such things, too.
