### PR TITLE
Bug fix: checks that user file was specified for API

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,7 @@ $user_file = preg_replace('/\.mit-license\..*$/', '', $_SERVER["HTTP_HOST"]);
 $user_file = preg_replace('/[^a-z0-9\-]/', '', $user_file);
 $user_file = 'users/'.$user_file.'.json';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && $user_file != '') {
   try {
     $data = json_decode(file_get_contents('php://input'));
     if (!property_exists($data, 'copyright')) {


### PR DESCRIPTION
Quick fix to check that a subdomain/user file was indeed specified before doing anything - I tried to POST straight to "mit-license.org" and now the site shows my details.
