### PR TITLE
if the provided year is this year, don't show it twice

### DIFF
--- a/index.php
+++ b/index.php
@@ -99,7 +99,7 @@ if (count($match) > 1) {
     $year = $match[2];
   }
   if ($match[1]) {
-    $year = $match[1] . '-' . $year;
+    $year = $match[1] == $year ? $year : $match[1] . '-' . $year;
   }
   $request = array_pop($request_uri);
 }


### PR DESCRIPTION
http://mit-license.org/2011 shows “copyright 2011-2011,” which should really say just “2011.”
