### PR TITLE
New theme: plaintext

### DIFF
--- a/themes/plaintext.css
+++ b/themes/plaintext.css
@@ -1,0 +1,7 @@
+@import url(http://fonts.googleapis.com/css?family=Inconsolata);
+body {
+  max-width: 625px;
+}
+body, h1, h2, h3, h4, h5, h6 {
+  font: normal 15px Inconsolata, Consolas, monospace;
+}

--- a/users/benbarber.json
+++ b/users/benbarber.json
@@ -1,3 +1,4 @@
 {
-  "copyright": "Benjamin Barber"
+  "copyright": "Benjamin Barber",
+  "theme": "plaintext"
 }


### PR DESCRIPTION
Hey Remy,

I added a new theme called "plaintext" which has a minimalist style similar to the "txt" format and license.txt.

The only value this theme has over using "format": "txt" is that the "Fork this project..." footer link is maintained.

If you decide to not accept the theme, please update my user config (users/benbarber.json) to use "format": "txt".

Thanks Remy!
