### PR TITLE
Send txt version if user agent is curl

### DIFF
--- a/index.php
+++ b/index.php
@@ -70,6 +70,11 @@ if ($cname && file_exists($user_file)) {
   $holder = "&lt;copyright holders&gt;";
 }
 
+// Return txt license if User-Agent is "curl"
+if (!strncmp(strtolower($_SERVER['HTTP_USER_AGENT']), "curl", 4)) {
+  $format = 'txt';
+}
+
 /**
  * Now process the request url. Optional parts of the url are (in order):
  * [sha]/[year|year-range]/license.[format]


### PR DESCRIPTION
This change adds user agent sniffing behavior similar to other tools (such as http://ifconfig.me).

This makes:

```
curl http://rem.mit-license.org
```

Equivalent to 

```
curl http://rem.mit-license.org/license.txt
```

I made this change because primarily it allows easier creation of LICENSE.txt files:

```
curl http://rem.mit-license.org > LICENSE.txt
```

It seems like the default version when using curl should always be the txt version since scraping the HTML version from a command line tool isn't useful.
