### PR TITLE
Update oojs.json

### DIFF
--- a/users/oojs.json
+++ b/users/oojs.json
@@ -1,1 +1,6 @@
-{"copyright":"OOJS Team and other contributors","url":"https://github.com/trevorparscal/oojs","format":"html","theme":"double-windsor"}
+{
+	"copyright": "OOjs Team and other contributors",
+	"url": "https://github.com/wikimedia/oojs",
+	"format": "html",
+	"theme":"double-windsor"
+}


### PR DESCRIPTION
- Repo moved to @wikimedia
  <br>per https://github.com/trevorparscal/oojs (now a fork of wikimedia/oojs)
- Title is OOjs instead of OOJS
  <br>per https://github.com/wikimedia/oojs/commit/82d5405480d066cb3d5460be0f7befc9f8dfa0d1
