### PR TITLE
removed url from copyright property

### DIFF
--- a/users/frisb.json
+++ b/users/frisb.json
@@ -1,5 +1,5 @@
 {
-  "copyright": "frisB, http://frisB.com",
+  "copyright": "frisB",
   "url": "http://frisB.com",
   "email": "play@frisb.com"
   "theme": "default",


### PR DESCRIPTION
Copyright does not seem to be rendering properly at [frisb.mit-license.org](http://frisb.mit-license.org), I have removed the url from the copyright property.
