### PR TITLE
Fix Chrome errors

### DIFF
--- a/LICENSE.html
+++ b/LICENSE.html
@@ -3,7 +3,7 @@
 <head>
 <title>MIT License</title>
 <meta charset=utf-8>
-<meta name=viewport content="width=device-width, initial-scale=0.70;">
+<meta name=viewport content="width=device-width, initial-scale=0.7">
 <!--
 Welcome fellow open source developer. This project is here for you to
 link to if you're like me and keep forgetting to include the 


### PR DESCRIPTION
>(index):6 The value "0.70;" for key "initial-scale" was truncated to its numeric prefix.
>(index):6 Error parsing a meta element's content: ';' is not a valid key-value pair separator. Please use ',' instead.