### PR TITLE
Remove negative margin-top in eula-modern.css

### DIFF
--- a/themes/eula-modern.css
+++ b/themes/eula-modern.css
@@ -37,7 +37,6 @@ article {
   max-width: 700px;
   margin: 10px auto 0px;
   text-align: justify;
-  margin-top: -65px;
 }
 
 @media (max-device-height: 699px) {


### PR DESCRIPTION
Negative margin lead to off-screen rendering of the "MIT License (MIT)" title (e.g. on my license page: http://zaploink.mit-license.org/)