### PR TITLE
Updated package.json to use new SPDX license expression version 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+SEE: http://rem.mit-license.org/

--- a/package.json
+++ b/package.json
@@ -11,9 +11,5 @@
     "test": "node test.js"
   },
   "bugs": { "url": "https://github.com/remy/mit-license/issues" },
-  "licenses": [
-    { "type": "MIT",
-      "url": "http://rem.mit-license.org/"
-    }
-  ]
+  "license" : "SEE LICENSE IN LICENSE"
 }

--- a/users/benniemosher.json
+++ b/users/benniemosher.json
@@ -1,1 +1,9 @@
-{"copyright":"Bennie Mosher"}
+{
+  "copyright": "Bennie Mosher, https://benniemosher.com",
+  "url": "https://benniemosher.com",
+  "email": "benniemosher@gmail.com",
+  "format": "html",
+  "gravatar": true,
+  "version": "117ac5a405b332fe2f0344400b0ec50004c256b3",
+  "theme": "default"
+}


### PR DESCRIPTION
According to the docs on npmjs.com and the warning output when running
`npm install`, the license element in `package.json` was invalid. NPM
has updated their requirements to use the new SPDX license expression
syntax version 2.0, and the license expression that was being used is
now deprecated. I updated the license field to use the new valid
expression. For more information, please see:
https://docs.npmjs.com/files/package.json#license