### PR TITLE
Allow multiple copyright holders

### DIFF
--- a/users/test-new.json
+++ b/users/test-new.json
@@ -1,0 +1,1 @@
+{"copyright":[{"name":"Mike McNeil","url":"http://www.mikemcniel.com","email":"mike@mcneil.com"},{"name":"efreak","url":"http://localhost","email":"efreak@efreakbnc.net"}]}


### PR DESCRIPTION
My server is set up for nginx + nodejs, not php; however the stdout from running with `$_SERVER['HTTP_HOST']` set appears to be correctly formatted.

See #659 for discussion.

I've allowed for setting the gravatar address directly in the gravatar property itself, since there's no longer any need for a root-level email address (this also allows setting up a gravatar at a single-use email address for a project-level gravatar).

The old format should continue to work just fine, however the new format is as follows below.

``` javascript
{
    copyright: [
        name: "Anonymous",
        url: "http://www.github.com",
        email: "some@email.address"
    ],
    format: "html",
    gravatar: "some@email.address",
    version: "somehash",
    theme: "flesch"
}
```

Some future suggestions since this is now a multi-user copyright:
- Instead of gravatar (or better, alongside it--to prevent breakage), allow a url for a project logo
- Use an [📧](http://emojipedia.org/e-mail-symbol/) for the email link, rather than displaying it, otherwise this could get rather long for large projects.
- Validate the email field.
- This would be quite a bit more complex, but it should still be relatively simple to allow copyright changing via a webpage, with authorization through github openid/oauth/whatever they use.
- For projects that change frequently, allow the json file to be located elsewhere on the web (such as in their github project), and allow a field to fetch it. This could even be rewritten so everything happens client-side with javascript.
