### PR TITLE
Update VisualEditor authors file link

### DIFF
--- a/users/ve.json
+++ b/users/ve.json
@@ -1,1 +1,1 @@
-{"copyright":"VisualEditor Team and others","url":"https:\/\/git.wikimedia.org\/blob\/VisualEditor%2FVisualEditor\/master\/AUTHORS.txt","format":"html","theme":"double-windsor"}
+{"copyright":"VisualEditor Team and others","url":"https:\/\/phabricator.wikimedia.org\/diffusion\/GVED\/browse\/master\/AUTHORS.txt","format":"html","theme":"double-windsor"}


### PR DESCRIPTION
git subdomain now redirects to phabricator diffusion home page rather than directly to the file.