### PR TITLE
WIP - Add MIT License Tools hyperlink to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Now I can always include http://rem.mit-license.org in all my projects which lin
 
 ## Requesting your own MIT license page
 
-You can fork this project, send me a pull request and wait for me to pull (which I'll do as quickly as possible) or if the user is still available you can do it yourself from the command line:
+One way is to use [MIT License Tools](https://richienb.github.io/mit-license-tools/) but you can also fork this project, send me a pull request and wait for me to pull (which I'll do as quickly as possible) or if the user is still available you can do it yourself from the command line:
 
 ```bash
 curl -d'{ "copyright": "Remy Sharp" }' https://rem.mit-license.org


### PR DESCRIPTION
I have created a streamlined tool which leverages the MIT License API along with a nice user interface to further assist users to create their new license page without the need of a specialised computer with curl or other `HTTP POST` command line interface installed. You can take a look at the URL I added in the README [here](https://richienb.github.io/mit-license-tools/).

UPDATE:
~~At the moment, the API is returning the following message:
`>>> curl API has been temporarily disabled. Please send a pull request in the short term. Service will resume as normal again soon`. Therefore, the tool doesn't seem to be functioning as intended due to this issue. Once the API goes back up, I'll be able to push some more patches to the source code of the site.~~

~~I'm currently redesigning the generator service and I'm going to wait until at least #1355 is merged before marking this as ready.~~

~~I've finished [redesigning the service](https://codepen.io/Richienb/full/xNmMBJ) and am now only waiting for #1355 to be merged.~~

The PR was merged so I will update the code shortly.

Thank you.

<!--
#### Before you create your license page

Hosting costs $7 a month. I need help, so please donate a few months to keep this service going.

I've already had support to run the domain until 2032, but the hosting needs help too.

**[Please donate and keep this project running](https://www.paypal.me/rem)**
-->

