### PR TITLE
Update 8bits theme, added correct preview URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Current available themes:
 * material - [preview](http://ahaasler.github.io/mit-license-material-theme/) (by [@ahaasler](https://github.com/ahaasler)). *Available colours: blue gray (default), red, pink, purple, deep purple, indigo, blue, light blue, cyan, teal, green, light green, lime, yellow, amber, orange, deep orange, brown and grey. To use a specific colour, add it as a dash-separated suffix on the theme name, such as `material-deep-orange`.*
 * hmt-blue - [preview](https://jsbin.com/naqorar/) (by [@J2TeaM](https://github.com/J2TeaM))
 * dusk - [preview](https://output.jsbin.com/giqivoh) (by [@georapbox](https://github.com/georapbox))
-* 8bits - [preview](https://gogoout.mit-license.org/) (by [@jorge-matricali](https://github.com/jorge-matricali)). *Available colours: monochrome, monochrome-white, monochrome-blue-white. To use a specific colour, add it as a dash-separated suffix on the theme name, such as `8bits-monochrome`.*
+* 8bits - [preview](https://matricali.github.io/mit-license-8bits-theme/) (by [@matricali](https://github.com/matricali)). *Available colours: monochrome, monochrome-white, monochrome-blue-white, monochrome-green, monochrome-amber. To use a specific colour, add it as a dash-separated suffix on the theme name, such as `8bits-monochrome`.*
 * hacker - [preview](https://tommy.mit-license.org/) (by [@TommyPujol06](https://github.com/TommyPujol06))
 
 ## Formats & URLs
@@ -257,7 +257,7 @@ Hosting contributions:
 * [zhengyi-yang](https://github.com/zhengyi-yang) 5 months
 * [catodd](https://github.com/catodd) 2 months
 * [lrz0](https://github.com/lrz0) 1 month
-* [jorge-matricali](https://github.com/jorge-matricali) 3 months
+* [matricali](https://github.com/matricali) 3 months
 * [youchenlee](https://github.com/youchenlee) 12 months
 * [ramsey](https://github.com/ramsey) 12 months
 * [rmm5t](https://github.com/rmm5t) 1 month

--- a/themes/8bits-monochrome-amber.css
+++ b/themes/8bits-monochrome-amber.css
@@ -1,17 +1,17 @@
-/* 8bits theme v1.1.0 by Jorge Matricali, https://github.com/matricali/mit-license-8bits-theme */
+/* 8bit theme v1.0.0 by Jorge Matricali, https://github.com/matricali/mit-license-8bits-theme */
 /* MIT License https://jorge-matricali.mit-license.org/ */
 @import url('https://fonts.googleapis.com/css?family=PT+Mono|VT323');
 body {
   font-family: 'PT Mono', monospace;
   padding: .4em;
   font-size: 1.1em;
-  background: #00f;
-  color: #fff;
+  background: #000;
+  color: #ffbf00;
 }
 a:link,
 a:visited {
   text-decoration: none;
-  color: #fff;
+  color: #ffbf00;
 }
 article {
   display: block;
@@ -21,7 +21,7 @@ article {
   margin: 10px auto 0;
 }
 article h1 {
-  color: #fff;
+  color: #ffbf00;
   width: 100%;
   margin: 0 auto;
   padding-top: 1.5em;
@@ -38,7 +38,7 @@ article h1 + p {
 }
 article h1 + p a:link,
 article h1 + p a:visited {
-  color: #fff;
+  color: #ffbf00;
 }
 article p {
   padding: 0 2em;
@@ -93,9 +93,9 @@ footer {
   }
 }
 img {
-  -webkit-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  -moz-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  -ms-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  -o-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
+  -webkit-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10);
+  -moz-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10);
+  -ms-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10);
+  -o-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10);
+  filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10);
 }

--- a/themes/8bits-monochrome-green.css
+++ b/themes/8bits-monochrome-green.css
@@ -5,13 +5,13 @@ body {
   font-family: 'PT Mono', monospace;
   padding: .4em;
   font-size: 1.1em;
-  background: #00f;
-  color: #fff;
+  background: #000;
+  color: #0f0;
 }
 a:link,
 a:visited {
   text-decoration: none;
-  color: #fff;
+  color: #0f0;
 }
 article {
   display: block;
@@ -21,7 +21,7 @@ article {
   margin: 10px auto 0;
 }
 article h1 {
-  color: #fff;
+  color: #0f0;
   width: 100%;
   margin: 0 auto;
   padding-top: 1.5em;
@@ -38,7 +38,7 @@ article h1 + p {
 }
 article h1 + p a:link,
 article h1 + p a:visited {
-  color: #fff;
+  color: #0f0;
 }
 article p {
   padding: 0 2em;
@@ -93,9 +93,9 @@ footer {
   }
 }
 img {
-  -webkit-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  -moz-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  -ms-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  -o-filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
-  filter: contrast(700%) invert(100%) brightness(80%) sepia(100%) saturate(5) invert(100%);
+  -webkit-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10) hue-rotate(40deg);
+  -moz-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10) hue-rotate(40deg);
+  -ms-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10) hue-rotate(40deg);
+  -o-filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10) hue-rotate(40deg);
+  filter: contrast(700%) sepia(100%) saturate(100) sepia(100%) saturate(10) hue-rotate(40deg);
 }

--- a/themes/8bits-monochrome-white.css
+++ b/themes/8bits-monochrome-white.css
@@ -1,2 +1,101 @@
-/* 8bits theme v1.0.0 by @jorge-matricali, https://github.com/jorge-matricali/mit-license-8bits-theme */
-@import url('https://fonts.googleapis.com/css?family=PT+Mono|VT323');body{font-family:'PT Mono',monospace;padding:.4em;font-size:1.1em;background:#fff;color:#000}a:link,a:visited{text-decoration:none;color:#000}article{display:block;margin:1em;position:relative;max-width:800px;margin:10px auto 0}article h1{color:#000;width:100%;margin:0 auto;padding-top:1.5em;font-size:3em}article h1,article h1+p{font-family:'VT323',monospace;padding-left:6%}article h1+p{margin-top:0;margin-bottom:3em}article h1+p a:link,article h1+p a:visited{color:#000}article p{padding:0 2em;text-align:justify}article p:last-child{padding-bottom:1.8em;font-size:.9em}footer{margin:0 auto;font-size:.8em;text-align:center}#gravatar{display:block;float:right}@media (min-width:750px){#gravatar{position:absolute;top:4em;right:3em}#gravatar+h1+p+p{padding-top:2em}h1+p{padding-right:6em}h1+p+p{padding-top:.8em}}@media (max-width:750px){body{font-size:14px}#gravatar{position:relative;top:4em;right:2em}article h1+p{padding-bottom:1em}article h1+p+p{padding-top:.8em}footer{padding-bottom:4em}}img{-webkit-filter:contrast(250%) grayscale(100%);-moz-filter:contrast(325%) grayscale(100%);-ms-filter:contrast(250%) grayscale(100%);-o-filter:contrast(250%) grayscale(100%);filter:contrast(325%) grayscale(100%)}
+/* 8bits theme v1.1.0 by Jorge Matricali, https://github.com/matricali/mit-license-8bits-theme */
+/* MIT License https://jorge-matricali.mit-license.org/ */
+@import url('https://fonts.googleapis.com/css?family=PT+Mono|VT323');
+body {
+  font-family: 'PT Mono', monospace;
+  padding: .4em;
+  font-size: 1.1em;
+  background: #fff;
+  color: #000;
+}
+a:link,
+a:visited {
+  text-decoration: none;
+  color: #000;
+}
+article {
+  display: block;
+  margin: 1em;
+  position: relative;
+  max-width: 800px;
+  margin: 10px auto 0;
+}
+article h1 {
+  color: #000;
+  width: 100%;
+  margin: 0 auto;
+  padding-top: 1.5em;
+  font-size: 3em;
+}
+article h1,
+article h1 + p {
+  font-family: 'VT323', monospace;
+  padding-left: 6%;
+}
+article h1 + p {
+  margin-top: 0;
+  margin-bottom: 3em;
+}
+article h1 + p a:link,
+article h1 + p a:visited {
+  color: #000;
+}
+article p {
+  padding: 0 2em;
+  text-align: justify;
+}
+article p:last-child {
+  padding-bottom: 1.8em;
+  font-size: 0.9em;
+}
+footer {
+  margin: 0 auto;
+  font-size: .8em;
+  text-align: center;
+}
+#gravatar {
+  display: block;
+  float: right;
+}
+@media (min-width: 750px) {
+  #gravatar {
+    position: absolute;
+    top: 4em;
+    right: 3em;
+  }
+  #gravatar + h1 + p + p {
+    padding-top: 2em;
+  }
+  h1 + p {
+    padding-right: 6em;
+  }
+  h1 + p + p {
+    padding-top: 0.8em;
+  }
+}
+@media (max-width: 750px) {
+  body {
+    font-size: 14px;
+  }
+  #gravatar {
+    position: relative;
+    top: 4em;
+    right: 2em;
+  }
+  article h1 + p {
+    padding-bottom: 1em;
+  }
+  article h1 + p + p {
+    padding-top: 0.8em;
+  }
+  footer {
+    padding-bottom: 4em;
+  }
+}
+img {
+  -webkit-filter: contrast(700%) grayscale(100%) saturate(100);
+  -moz-filter: contrast(700%) grayscale(100%) saturate(100);
+  -ms-filter: contrast(700%) grayscale(100%) saturate(100);
+  -o-filter: contrast(700%) grayscale(100%) saturate(100);
+  filter: contrast(700%) grayscale(100%) saturate(100);
+}

--- a/themes/8bits-monochrome.css
+++ b/themes/8bits-monochrome.css
@@ -1,2 +1,101 @@
-/* 8bits theme v1.0.0 by @jorge-matricali, https://github.com/jorge-matricali/mit-license-8bits-theme */
-@import url('https://fonts.googleapis.com/css?family=PT+Mono|VT323');body{font-family:'PT Mono',monospace;padding:.4em;font-size:1.1em;background:#000;color:#fff}a:link,a:visited{text-decoration:none;color:#fff}article{display:block;margin:1em;position:relative;max-width:800px;margin:10px auto 0}article h1{color:#fff;width:100%;margin:0 auto;padding-top:1.5em;font-size:3em}article h1,article h1+p{font-family:'VT323',monospace;padding-left:6%}article h1+p{margin-top:0;margin-bottom:3em}article h1+p a:link,article h1+p a:visited{color:#fff}article p{padding:0 2em;text-align:justify}article p:last-child{padding-bottom:1.8em;font-size:.9em}footer{margin:0 auto;font-size:.8em;text-align:center}#gravatar{display:block;float:right}@media (min-width:750px){#gravatar{position:absolute;top:4em;right:3em}#gravatar+h1+p+p{padding-top:2em}h1+p{padding-right:6em}h1+p+p{padding-top:.8em}}@media (max-width:750px){body{font-size:14px}#gravatar{position:relative;top:4em;right:2em}article h1+p{padding-bottom:1em}article h1+p+p{padding-top:.8em}footer{padding-bottom:4em}}img{-webkit-filter:contrast(250%) grayscale(100%);-moz-filter:contrast(325%) grayscale(100%);-ms-filter:contrast(250%) grayscale(100%);-o-filter:contrast(250%) grayscale(100%);filter:contrast(325%) grayscale(100%)}
+/* 8bits theme v1.1.0 by Jorge Matricali, https://github.com/matricali/mit-license-8bits-theme */
+/* MIT License https://jorge-matricali.mit-license.org/ */
+@import url('https://fonts.googleapis.com/css?family=PT+Mono|VT323');
+body {
+  font-family: 'PT Mono', monospace;
+  padding: .4em;
+  font-size: 1.1em;
+  background: #000;
+  color: #fff;
+}
+a:link,
+a:visited {
+  text-decoration: none;
+  color: #fff;
+}
+article {
+  display: block;
+  margin: 1em;
+  position: relative;
+  max-width: 800px;
+  margin: 10px auto 0;
+}
+article h1 {
+  color: #fff;
+  width: 100%;
+  margin: 0 auto;
+  padding-top: 1.5em;
+  font-size: 3em;
+}
+article h1,
+article h1 + p {
+  font-family: 'VT323', monospace;
+  padding-left: 6%;
+}
+article h1 + p {
+  margin-top: 0;
+  margin-bottom: 3em;
+}
+article h1 + p a:link,
+article h1 + p a:visited {
+  color: #fff;
+}
+article p {
+  padding: 0 2em;
+  text-align: justify;
+}
+article p:last-child {
+  padding-bottom: 1.8em;
+  font-size: 0.9em;
+}
+footer {
+  margin: 0 auto;
+  font-size: .8em;
+  text-align: center;
+}
+#gravatar {
+  display: block;
+  float: right;
+}
+@media (min-width: 750px) {
+  #gravatar {
+    position: absolute;
+    top: 4em;
+    right: 3em;
+  }
+  #gravatar + h1 + p + p {
+    padding-top: 2em;
+  }
+  h1 + p {
+    padding-right: 6em;
+  }
+  h1 + p + p {
+    padding-top: 0.8em;
+  }
+}
+@media (max-width: 750px) {
+  body {
+    font-size: 14px;
+  }
+  #gravatar {
+    position: relative;
+    top: 4em;
+    right: 2em;
+  }
+  article h1 + p {
+    padding-bottom: 1em;
+  }
+  article h1 + p + p {
+    padding-top: 0.8em;
+  }
+  footer {
+    padding-bottom: 4em;
+  }
+}
+img {
+  -webkit-filter: contrast(700%) grayscale(100%) saturate(100);
+  -moz-filter: contrast(700%) grayscale(100%) saturate(100);
+  -ms-filter: contrast(700%) grayscale(100%) saturate(100);
+  -o-filter: contrast(700%) grayscale(100%) saturate(100);
+  filter: contrast(700%) grayscale(100%) saturate(100);
+}

--- a/users/jorge-matricali.json
+++ b/users/jorge-matricali.json
@@ -1,8 +1,8 @@
 {
   "copyright": "Jorge Matricali",
-  "url": "https://github.com/jorge-matricali",
+  "url": "https://github.com/matricali",
   "email": "jorgematricali@gmail.com",
   "format": "html",
-  "theme": "8bits-monochrome-white",
+  "theme": "8bits-monochrome-amber",
   "gravatar": true
 }


### PR DESCRIPTION
- Added 8bits-monochrome-green
- Added 8bits-monochrome-amber
- Improved 8bits image effect with pure CSS filters
- **Updated 8bits theme preview URL**
- Updated my actual Github username (from `jorge-matricali` to `matricali`)
- Changed my own theme to "8bits-monochrome-amber"

This pull request is partially related to #1327