### PR TITLE
Delete duplicate user file causing tricky status on case-insensitive filesystems

### DIFF
--- a/users/Ankur.json
+++ b/users/Ankur.json
@@ -1,2 +1,0 @@
-{"copyright":"Ankur Jaiswal","email":"aj17@iitbbs.ac.in","theme": "flesch","format":"html","gravatar": true}
-


### PR DESCRIPTION
This removed file, `Ankur.json`, was functionally identical to `ankur.json` (a different theme). These files don't coexist well on case-insensitive filesystems (e.g. Mac OS' APFS/HFS+ defaults), including perniciously persistent Modified states that make stashing/rebasing/generally useful subcommands difficult to execute.

`ankur.json` is the version preferred [by the site](https://ankur.mit-license.org), so keeping it.