### PR TITLE
Add 'anon-pro' theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Current available themes:
 * dusk - [preview](https://output.jsbin.com/giqivoh) (by [@georapbox](https://github.com/georapbox))
 * 8bits - [preview](https://matricali.github.io/mit-license-8bits-theme/) (by [@matricali](https://github.com/matricali)). *Available colours: monochrome, monochrome-white, monochrome-blue-white, monochrome-green, monochrome-amber. To use a specific colour, add it as a dash-separated suffix on the theme name, such as `8bits-monochrome`.*
 * hacker - [preview](https://tommy.mit-license.org/) (by [@TommyPujol06](https://github.com/TommyPujol06))
+* anon-pro - [preview](https://b.mit-license.org) (by [@bbbrrriiiaaannn](https://github.com/bbbrrriiiaaannn))
 
 ## Formats & URLs
 

--- a/themes/anon-pro.css
+++ b/themes/anon-pro.css
@@ -41,7 +41,7 @@ article h1 {
   margin-bottom: 24px
 }
 
-article p:first-of-type{
+article p:first-of-type {
   font-style: italic;
 }
 
@@ -69,7 +69,10 @@ article a:hover, article a:focus {
   outline: none;
 }
 
-footer { position: absolute; }
+footer {
+  position: absolute;
+}
+
 footer a {
   position: fixed;
   bottom: 25px;
@@ -89,7 +92,3 @@ footer a:hover, footer a:focus {
   box-shadow: 10px 10px 0px #daa;
   outline: none;
 }
-
-
-
-

--- a/themes/anon-pro.css
+++ b/themes/anon-pro.css
@@ -1,0 +1,95 @@
+@import url('https://fonts.googleapis.com/css?family=Anonymous+Pro:400,400i,700');
+
+* {
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Anonymous Pro', monospace;
+  font-size: 1.1em;
+  background: #fbfbfb;
+  color: black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+article {
+  max-width: 90%;
+  min-height: 100vh;
+  padding: 30px 0 120px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+@media (min-width: 770px) {
+  article {
+    max-width: 693px;
+  }
+}
+
+article img {
+  display: none;
+}
+
+article h1 {
+  font-size: 36px;
+  font-weight: 400;
+  margin-bottom: 24px
+}
+
+article p:first-of-type{
+  font-style: italic;
+}
+
+article p {
+  margin-bottom: 1em;
+  font-size: 24px;
+  line-height: 1.4;
+}
+
+article p:last-of-type {
+  font-style: italic;
+}
+
+article a {
+  color: black;
+  text-decoration: none;
+  background-position: center bottom;
+  background-size: 100% 3px;
+  background-repeat: no-repeat;
+  background-image: linear-gradient(#38f, #38f);
+}
+
+article a:hover, article a:focus {
+  background-color: #38f;
+  outline: none;
+}
+
+footer { position: absolute; }
+footer a {
+  position: fixed;
+  bottom: 25px;
+  left: 0;
+  color: white;
+  max-width: 320px;
+  background: #db2d20;
+  padding: 5px 20px 5px 40px;
+  display: block;
+  transform: translateX(-20px);
+  transition: all .2s ease;
+  box-shadow: 5px 5px 0px #ddd;
+}
+
+footer a:hover, footer a:focus {
+  transform: translateX(0);
+  box-shadow: 10px 10px 0px #daa;
+  outline: none;
+}
+
+
+
+

--- a/users/b.json
+++ b/users/b.json
@@ -1,5 +1,5 @@
 {
   "copyright": "Brian Seward, http://brianseward.com",
   "url": "http://brianseward.com",
-  "theme": "default"
+  "theme": "anon-pro"
 }


### PR DESCRIPTION
This adds a theme called `anon-pro`, a responsive, contemporary, easy-on-the-eyes option named for its trendy typeface. It includes a prominent, catchy footer call-to-action linking to this project to encourage others to participate. A static preview can be found at https://jsbin.com/gohiliwisi/edit?output

Originally proposed in #1329 alongside a larger README change, this pull request is for the theme alone (with the other, README-focused change coming later to avoid merge-conflicting myself)