### PR TITLE
Re-enable API

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,9 +16,6 @@ if (count($match) == 2) {
 $user_file = 'users/' . $cname . '.json';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && $cname) {
-  echo ('>>> curl API has been temporarily disabled. Please send a pull request in the short term. Service will resume as normal again soon ❤');
-  exit;
-
   try {
     $data = json_decode(file_get_contents('php://input'));
     if (!property_exists($data, 'copyright')) {


### PR DESCRIPTION
The cURL has been disabled for 2 years. It's time to turn it back on. (Closes #1299).