### PR TITLE
fix: Wrong theme name for ctoon

### DIFF
--- a/users/ctoon.json
+++ b/users/ctoon.json
@@ -2,5 +2,5 @@
   "copyright": "CTOON",
   "url": "https://ctoon.network",
   "email": "contact@ctoon.network",
-  "theme": "material-gray"
+  "theme": "material"
 }


### PR DESCRIPTION
Sorry, since gray is the default the suffix isn't needed.

Also I just sent 6 more months on PayPal. 😉 
