### PR TITLE
Add static file generation

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,48 @@
+name: Static MIT License Generation
+on:
+  # Schedule updates
+  schedule: [{cron: "0 0 1 * *"}]
+  push: {branches: "master"}
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - name: Add Domain to Hosts
+        run: |
+          echo "127.0.0.1       ${{ github.actor }}.localhost" | sudo tee -a /etc/hosts
+      - name: Install Dependencies
+        run: |
+          yarn install
+      - name: Run Server in Background
+        run: |
+          yarn start &
+          sleep 5
+      - name: Get Files
+        run: |
+          export THEME="`cat users/${{ github.actor }}.json | jq .theme | sed 's/"//g'`.css"
+          rm -r docs # just to make sure everything goes smoothly
+          mkdir -p docs
+          mkdir -p docs/themes
+          cp themes/$THEME docs/themes/$THEME
+          wget http://${{ github.actor }}.localhost:8080/ -O docs/index.html
+          wget http://${{ github.actor }}.localhost:8080/license.txt -O docs/license.txt
+          sed -i 's|/themes/|/mit-license/themes/|g' docs/index.html
+      - name: Commit and Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "Github Action"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git checkout ${{ github.head_ref }}
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "there are changes";
+            git add -A
+            git commit -m "[bot] Update static files."
+            git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" ${{ github.head_ref }}
+          else
+            echo "no changes";
+          fi

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 I always forget to add a `LICENSE` file to my projects, so I wanted to link to a single resource that would always be up to date and would always have my details online.
 
-Why keep this to myself, there are two ways to create your _own_ MIT license page:
+Why keep this to myself, there are four ways to create your _own_ MIT license page:
 
 1.  Use the generator tool (easiest)
 2.  Make a request to the API (details below)
 3.  Fork this project and send a pull request
+4.  Fork this project and use it as a static site (details below)
 
 Now I can always include <https://rem.mit-license.org> in all my projects which links `rem` (the CNAME) against my copyright holder name `Remy Sharp` - all stored in the `users` directory.
 
@@ -205,6 +206,7 @@ Current available themes:
 * richienb - [preview](https://richienb.github.io/mit-license-richienb-theme/demo) (by [@Richienb](https://github.com/Richienb)). *Dark variant: `richienb-dark` - [preview](https://richienb.github.io/mit-license-richienb-theme/demo-dark).*
 * tryhtml - [preview](https://output.jsbin.com/cawihuwuku) (by [@abranhe](https://github.com/abranhe))
 * clarity - [preview](https://output.jsbin.com/likezir) (by [@Richienb](https://github.com/Richienb))
+* darkblog - [preview](https://chand1012.dev/mit-license/) (by [@chand1012](https://github.com/chand1012))
 
 ## Formats & URLs
 
@@ -234,6 +236,19 @@ Finally, the URL also supports pinning the year
 
 * <https://rem.mit-license.org/@2009>
     this is useful for when your software copyright should expire ([as discussed here](https://github.com/remy/mit-license/issues/771))
+
+## Static Hosting
+
+GitHub offers free static hosting via GitHub Pages, which can be used to host your very own license page statically. The above API endpoints will not work, but the site will be updated on a monthly basis to keep the year up to date. 
+
+Steps to host:
+
+1.  Fork this repository.
+2.  Add a `.json` file with your GitHub username as the name of the file and add the required fields as indicated [here](#the-userjson-file).
+3.  Push your changes.
+4.  Enable GitHub Pages in the repository settings. Make sure that the you set the `master` branch as the main branch and that the `docs` folder is used to get the page.
+
+That's it! You can navigate to `<your GitHub Username>.github.io/mit-license/` to see your static license! If you have a custom DNS to your GitHub Pages's main site, you can still access the license at `<your base url>/mit-license/`. The `license.txt` file also works, it can be accessed at `<your base url>/mit-license/license.txt`.
 
 ## Ways to contribute
 


### PR DESCRIPTION
The changes I made allow someone to simply fork the repo, add their information to the [`users`](https://github.com/remy/mit-license/tree/master/users) directory under their GitHub username, and enable GitHub Pages, and have their own GitHub-hosted version of the MIT License. I could have just used Jekyll or some other static site generator but this project was here and I know how to used GitHub Actions and GitHub Pages, so I wrote a GitHub Action, `static.yml` that would use the existing code to generate a static version of the user-specific MIT License. I also added [instructions](https://github.com/chand1012/mit-license/tree/56a5c39c6b857ff7a4da137bfe9ba70b13288e84#static-hosting) on how to do this yourself. Both the HTML and text versions of the license are supported, and ISC should work as well. An example of the statically-hosted version of the repo can be found [here](https://chand1012.dev/mit-license/), as well as the plaintext version [here](https://chand1012.dev/mit-license/license.txt).
