### PR TITLE
Delete progyadeep-moulik

### DIFF
--- a/users/progyadeep-moulik.json
+++ b/users/progyadeep-moulik.json
@@ -1,8 +1,0 @@
-{
-  "copyright": "Progyadeep Moulik",
-  "url": "https://proggy.ml",
-  "format": "html",
-  "license": "isc",
-  "theme": "default",
-  "gravatar": false
-}


### PR DESCRIPTION
I don't need my own MIT License page, hence I'm trying to delete it.