### PR TITLE
Delete 7automaton.json

### DIFF
--- a/users/7automaton.json
+++ b/users/7automaton.json
@@ -1,7 +1,0 @@
-{
-  "copyright": "7automaton",
-  "format": "html",
-  "license": "mit",
-  "theme": "default",
-  "gravatar": false
-}


### PR DESCRIPTION
My subdomain got added just as a test - I didn't know it'd give me a whole new official-looking subdomain. I don't want any licensing issues happening in the future if I forget about this page. Thanks.