### PR TITLE
switch CI workflow to use actions with node v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
         node-version:
           - 14
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
Github has removed node14 from the runners and deprecated node16 since it's past its end of life[1]. Workflows containing actions using old node versions emit deprecation warnings. This commit removes the warning by switching to latest stable versions of the affected actions.

Fixes #1713.

[1]: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

